### PR TITLE
AIX users fact - fix `uname` not found on EL 6 systems

### DIFF
--- a/facts.d/aix_local_nonsystem_users.sh
+++ b/facts.d/aix_local_nonsystem_users.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 # This will get a list of local users that are not a common system user.
 # These local users will have some attributes set to ensure they authenticate locally.
-PATH='/usr/bin:/usr/sbin'
+PATH='/bin:/sbin:/usr/bin:/usr/sbin'
 export PATH
 if [ `uname` == 'AIX' ]; then
     sysusers="root bin daemon sys adm uucp nobody lpd lp invscout snapp nuucp ipsec pconsole esaadmin sshd srvproxy virtuser"


### PR DESCRIPTION
On EL 6 systems (CentOS/RedHat), the `uname` binary lives in the /bin directory, but the aix_local_nonsystem_users.sh fact has a fixed PATH to /usr/bin and /usr/sbin and it makes puppet agent fail. 

```
puppet-agent[22481]: (Facter) external fact file "/opt/puppetlabs/puppet/cache/facts.d/aix_local_nonsystem_users.sh" had output on stderr: /opt/puppetlabs/puppet/cache/facts.d/aix_local_nonsystem_users.sh: line 6: uname: command not found
puppet-agent[22481]: (Facter) /opt/puppetlabs/puppet/cache/facts.d/aix_local_nonsystem_users.sh: line 6: [: ==: unary operator expected
```

This PR adds /bin and /sbin to the PATH var. 
